### PR TITLE
replace hard-coded Linux user with variable

### DIFF
--- a/tasks/configure/create-broker.yml
+++ b/tasks/configure/create-broker.yml
@@ -155,4 +155,4 @@
     creates: "{{ amq_broker_dir }}/{{ amq_broker_name }}"
   register: broker_created
   become: True
-  become_user: jboss
+  become_user: "{{ amq_user }}"


### PR DESCRIPTION
Real quick bug fix -- the Linux user that Ansible becomes to execute the create-broker task needs to come from a variable